### PR TITLE
test(tinder-backend): deleted match ID

### DIFF
--- a/apps/2CD/tinder/backend/specs/resolvers/mutations/unMatch/deleted-match.spec.ts
+++ b/apps/2CD/tinder/backend/specs/resolvers/mutations/unMatch/deleted-match.spec.ts
@@ -1,0 +1,46 @@
+
+import Match from 'src/models/match';
+import { unMatched } from 'src/resolvers/mutations/unMatch/deleted-match';
+
+jest.mock('src/models/match');
+
+describe('unMatched', () => {
+  const mockId = '64b1fbd34e0f03012b345678';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully delete a match', async () => {
+    (Match.findOneAndDelete as jest.Mock).mockResolvedValueOnce({ _id: mockId });
+
+    const result = await unMatched(mockId);
+
+    expect(Match.findOneAndDelete).toHaveBeenCalledWith({ _id: mockId });
+    expect(result).toEqual({
+      success: true,
+      message: '1 match unmatched successfully',
+    });
+  });
+
+  it('should throw error if no match found', async () => {
+    (Match.findOneAndDelete as jest.Mock).mockResolvedValueOnce(null);
+
+    const result = await unMatched(mockId);
+
+    expect(Match.findOneAndDelete).toHaveBeenCalledWith({ _id: mockId });
+    expect(result).toEqual({
+      success: false,
+    });
+  });
+
+  it('should catch and handle unexpected errors', async () => {
+    (Match.findOneAndDelete as jest.Mock).mockRejectedValueOnce(new Error('DB error'));
+
+    const result = await unMatched(mockId);
+
+    expect(result).toEqual({
+      success: false,
+    });
+  });
+});

--- a/apps/2CD/tinder/backend/src/resolvers/index.ts
+++ b/apps/2CD/tinder/backend/src/resolvers/index.ts
@@ -8,6 +8,7 @@ import { updateUser } from './mutations/user/update-user';
 import { login } from './mutations/user/login';
 import { getMatchById } from './queries/match/get-match-by-id';
 import { getMyMatches } from './queries/match/get-my-matches';
+import { unMatched } from './mutations/unMatch/deleted-match';
 
 export const resolvers = {
   Mutation: {
@@ -16,14 +17,14 @@ export const resolvers = {
     registerUser,
     updateUser,
     login,
+    unMatched
   },
   Query: {
     getLikesFromUser,
     getLikesToUser,
 
-getMessage,
-        getMyMatches,
+    getMessage,
+    getMyMatches,
     getMatchById,
   },
-
 };

--- a/apps/2CD/tinder/backend/src/resolvers/mutations/unMatch/deleted-match.ts
+++ b/apps/2CD/tinder/backend/src/resolvers/mutations/unMatch/deleted-match.ts
@@ -1,0 +1,18 @@
+import Match from 'src/models/match';
+
+export const unMatched = async (_id: string) => {
+  try {
+    const result = await Match.findOneAndDelete({ _id });
+
+    if (!result) {
+      throw new Error('No matches found for this user');
+    }
+
+    return { success: true, message: "1 match unmatched successfully" };
+  } catch (error) {
+    console.error('Error not ', error);
+    return {
+      success: false,
+    };
+  }
+}; 

--- a/apps/2CD/tinder/backend/src/schemas/match.schema.ts
+++ b/apps/2CD/tinder/backend/src/schemas/match.schema.ts
@@ -11,4 +11,8 @@ export const typeDefs = gql`
     getMyMatches: [Match!]!
     getMatchById(id: ID!): Match
   }
+
+  extend type Mutation {
+    unMatched(_id: ID!): Match!
+  }
 `;

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@uidotdev/usehooks": "^2.4.1",
     "@vercel/kv": "1.0.0",
     "apollo-graphql": "0.9.7",
+    "apollo-server-express": "^3.13.0",
     "axios": "1.6.0",
     "bcrypt": "5.1.1",
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
1. Removed the unMatched function that deleted a match by _id from the Match model.
2. Tests deleted as the unMatched functionality is deprecated or removed.